### PR TITLE
Ignore case when evaluating custom dictionary words

### DIFF
--- a/qs_cfn_lint_rules/SentenceCase.py
+++ b/qs_cfn_lint_rules/SentenceCase.py
@@ -65,7 +65,7 @@ class Base(CloudFormationLintRule):
                 # if sentence starts with a proper noun then we don't need to check for sentence case
                 if sentence.startswith(pn):
                     word_no += 1
-                sentence = re.sub(r"\b" + re.escape(pn) + r"\b", "", sentence)
+                sentence = re.sub(r"\b" + re.escape(pn) + r"\b", "", sentence, flags=re.IGNORECASE)
             if len(sentence.strip()) > 1:
                 # Check that first letter of first word is UPPER
                 if sentence[0].upper() != sentence[0]:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Ignore case when evaluating custom dictionary words


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
