### PR TITLE
ModuleNotFoundError: No module named 'setuptools' fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.black]
 line-length = 79
 [build-system]
-requires = ["poetry"]
+requires = ["setuptools", "poetry"]
 build-backend = "poetry.masonry.api"
 [tool.poetry]
 name = "qs_cfn_lint_rules"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ readme = "README.md"
 python = "*"
 cfn-lint = "<1.0.0,>=0.16.0"
 policyuniverse = "<2,>=1.3.5"
-pyspellchecker = "<0.5.0,>=0.4.0"
+pyspellchecker = ">=0.6.2,<1.0.0"
 
 [tool.poetry.scripts]
 wrapped-cfn-lint = 'qs_cfn_lint_rules.cfnlint_exit_code_wrapper:main'

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
     zip_safe=False,
     install_requires=[
         "cfn-lint>=0.16.0,<1.0.0",
-        "pyspellchecker>=0.4.0,<0.5.0",
+        "pyspellchecker>=0.6.2,<1.0.0",
         "policyuniverse>=1.3.5,<2",
     ],
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",

--- a/setup.py
+++ b/setup.py
@@ -58,5 +58,8 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
 )


### PR DESCRIPTION
* Fix `ModuleNotFoundError: No module named 'setuptools'` issue from poetry interop issue
* Standardize `pyspellchecker` version requirements to support current
* Add classifiers for python 3.8, 3.9, 3.10


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
