### PR TITLE
Fixing bug where Custom::Blah is indicates the file is not CFN

### DIFF
--- a/qs_cfn_lint_rules/files_are_cfn.py
+++ b/qs_cfn_lint_rules/files_are_cfn.py
@@ -4,7 +4,7 @@ import argparse
 import sys
 from pathlib import Path
 
-TYPE_REGEX = r"([A-Za-z0-9]+::){2}([A-Za-z0-9]+)"
+TYPE_REGEX = r"([A-Za-z0-9]+::){1,2}([A-Za-z0-9]+)"
 
 
 def is_cfn(inputs):


### PR DESCRIPTION
- typo
- "Custom::Blah" is a valid CFN resource type
